### PR TITLE
refactor error components for consistency

### DIFF
--- a/packages/snap/src/components/errors/Error.ts
+++ b/packages/snap/src/components/errors/Error.ts
@@ -1,13 +1,10 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
-import { heading, panel, text } from '@metamask/snaps-ui';
+import { Panel, heading, panel, text } from '@metamask/snaps-ui';
 
-export const ErrorComponent = (): OnTransactionResponse => {
-  return {
-    content: panel([
-      heading('Error while simulating transaction'),
-      text(
-        'Please contact support@walletguard.app if you continue seeing this issue.',
-      ),
-    ]),
-  };
+export const ErrorComponent = (): Panel => {
+  return panel([
+    heading('Error while simulating transaction'),
+    text(
+      'Please contact support@walletguard.app if you continue seeing this issue.',
+    ),
+  ]);
 };

--- a/packages/snap/src/components/errors/InsufficientFunds.ts
+++ b/packages/snap/src/components/errors/InsufficientFunds.ts
@@ -1,8 +1,5 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
-import { heading, panel } from '@metamask/snaps-ui';
+import { heading, panel, Panel } from '@metamask/snaps-ui';
 
-export const InsufficientFundsComponent = (): OnTransactionResponse => {
-  return {
-    content: panel([heading('Insufficient funds')]),
-  };
+export const InsufficientFundsComponent = (): Panel => {
+  return panel([heading('Insufficient funds')]);
 };

--- a/packages/snap/src/components/errors/Revert.ts
+++ b/packages/snap/src/components/errors/Revert.ts
@@ -1,13 +1,8 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
-import { heading, panel, text } from '@metamask/snaps-ui';
+import { Panel, heading, panel, text } from '@metamask/snaps-ui';
 
-export const RevertComponent = (): OnTransactionResponse => {
-  return {
-    content: panel([
-      heading('Revert warning'),
-      text(
-        'The transaction will be reverted and your gas fee will go to waste.',
-      ),
-    ]),
-  };
+export const RevertComponent = (): Panel => {
+  return panel([
+    heading('Revert warning'),
+    text('The transaction will be reverted and your gas fee will go to waste.'),
+  ]);
 };

--- a/packages/snap/src/components/errors/TooManyRequests.ts
+++ b/packages/snap/src/components/errors/TooManyRequests.ts
@@ -1,13 +1,8 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
-import { heading, panel, text } from '@metamask/snaps-ui';
+import { Panel, heading, panel, text } from '@metamask/snaps-ui';
 
-export const TooManyRequestsComponent = (): OnTransactionResponse => {
-  return {
-    content: panel([
-      heading('Slow down'),
-      text(
-        "We've detected too many requests from you. Please try again later.",
-      ),
-    ]),
-  };
+export const TooManyRequestsComponent = (): Panel => {
+  return panel([
+    heading('Slow down'),
+    text("We've detected too many requests from you. Please try again later."),
+  ]);
 };

--- a/packages/snap/src/components/errors/Unauthorized.ts
+++ b/packages/snap/src/components/errors/Unauthorized.ts
@@ -1,13 +1,10 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
-import { heading, panel, text } from '@metamask/snaps-ui';
+import { Panel, heading, panel, text } from '@metamask/snaps-ui';
 
-export const UnauthorizedComponent = (): OnTransactionResponse => {
-  return {
-    content: panel([
-      heading('Unauthorized'),
-      text(
-        'Please contact support@walletguard.app if you continue seeing this issue.',
-      ),
-    ]),
-  };
+export const UnauthorizedComponent = (): Panel => {
+  return panel([
+    heading('Unauthorized'),
+    text(
+      'Please contact support@walletguard.app if you continue seeing this issue.',
+    ),
+  ]);
 };

--- a/packages/snap/src/components/errors/mapper.ts
+++ b/packages/snap/src/components/errors/mapper.ts
@@ -1,4 +1,4 @@
-import { OnTransactionResponse } from '@metamask/snaps-types';
+import { Panel } from '@metamask/snaps-ui';
 import { ErrorType } from '../../types/simulateApi';
 import {
   ErrorComponent,
@@ -14,7 +14,7 @@ import {
  * @param errorType - The mapped error response based on status code or any simulation related issues.
  * @returns OnTransactionResposnse - the output for OnTransaction hook.
  */
-export function showErrorResponse(errorType: ErrorType): OnTransactionResponse {
+export function showErrorResponse(errorType: ErrorType): Panel {
   switch (errorType) {
     case ErrorType.Revert:
       return RevertComponent();

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -70,9 +70,13 @@ export const onTransaction: OnTransactionHandler = async ({
   );
 
   if (response.error) {
-    return showErrorResponse(response.error.type);
+    return {
+      content: showErrorResponse(response.error.type),
+    };
   } else if (!response.simulation || response.simulation?.error) {
-    return showErrorResponse(ErrorType.GeneralError);
+    return {
+      content: showErrorResponse(ErrorType.GeneralError),
+    };
   }
 
   if (


### PR DESCRIPTION
Creating a design pattern here: Components should always return `panel` instead of `OnTransactionResponse`

This improves testability and conforms to a consistent naming standard