### PR TITLE
Fix: approval change type & UI styling improvements

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet-guard-snap",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Protect your crypto with transaction insights and proactive security alerts.",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/wallet-guard/wallet-guard-snap"
   },
   "source": {
-    "shasum": "mv4xJVdaBEdavHcluuEkD5BzFdjT9CzyjtKFAWxP28s=",
+    "shasum": "w4NvRAfccOaNV+bHl+disCdDfMBbLdRkY6QFLVnDSOk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Protect your crypto with transaction insights and proactive security alerts.",
   "proposedName": "Wallet Guard",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/wallet-guard/wallet-guard-snap"
   },
   "source": {
-    "shasum": "w4NvRAfccOaNV+bHl+disCdDfMBbLdRkY6QFLVnDSOk=",
+    "shasum": "2yoyqVvqwRxZSasmeFXqWd2+BZNiIBr1CFM9ZQR2EsM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/__tests__/components/StateChangesComponent.test.ts
+++ b/packages/snap/src/__tests__/components/StateChangesComponent.test.ts
@@ -1,4 +1,4 @@
-import { panel } from '@metamask/snaps-ui';
+import { divider, panel } from '@metamask/snaps-ui';
 import {
   Currency,
   SimulatedGas,
@@ -113,6 +113,7 @@ describe('StateChangesComponent', () => {
     const expected = panel([
       // Asserts that Transfer comes before Receive
       AssetChangeComponent(StateChangeType.Transfer, transferChanges, gas),
+      divider(),
       AssetChangeComponent(StateChangeType.Receive, receiveChanges),
     ]);
     const actual = StateChangesComponent(stateChanges, gas);
@@ -194,6 +195,7 @@ describe('StateChangesComponent', () => {
     );
     const expected = panel([
       AssetChangeComponent(StateChangeType.Transfer, [], gas),
+      divider(),
       AssetChangeComponent(StateChangeType.Receive, receiveChanges),
     ]);
     const actual = StateChangesComponent(stateChanges, gas);

--- a/packages/snap/src/__tests__/components/assetChanges/AssetChangeComponent.test.ts
+++ b/packages/snap/src/__tests__/components/assetChanges/AssetChangeComponent.test.ts
@@ -33,7 +33,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are sending:'),
+      heading('➡️ You are sending:'),
       text('1 ETH ($2,000)'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Transfer, stateChanges);
@@ -66,7 +66,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are receiving:'),
+      heading('⬅️ You are receiving:'),
       text('1 ETH ($2,000.40)'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Receive, stateChanges);
@@ -99,7 +99,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are receiving:'),
+      heading('⬅️ You are receiving:'),
       text('CryptoKitty ($1,000)'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Receive, stateChanges);
@@ -132,7 +132,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are receiving:'),
+      heading('⬅️ You are receiving:'),
       text('CryptoKitty'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Receive, stateChanges);
@@ -165,7 +165,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are sending:'),
+      heading('➡️ You are sending:'),
       text('2 CryptoPunk ($3,000.33)'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Transfer, stateChanges);
@@ -198,7 +198,7 @@ describe('AssetChangeComponent', () => {
       },
     ];
     const expected = panel([
-      heading('You are receiving:'),
+      heading('⬅️ You are receiving:'),
       text('0.5 ETH ($1,000.49)'),
     ]);
     const actual = AssetChangeComponent(StateChangeType.Receive, stateChanges);
@@ -207,7 +207,7 @@ describe('AssetChangeComponent', () => {
 
   it('should handle empty stateChanges array correctly', () => {
     const stateChanges: StateChange[] = [];
-    const expected = panel([heading('You are sending:')]);
+    const expected = panel([heading('➡️ You are sending:')]);
     const actual = AssetChangeComponent(StateChangeType.Transfer, stateChanges);
     expect(actual).toStrictEqual(expected);
   });

--- a/packages/snap/src/__tests__/components/assetChanges/AssetChangeComponent.test.ts
+++ b/packages/snap/src/__tests__/components/assetChanges/AssetChangeComponent.test.ts
@@ -205,6 +205,40 @@ describe('AssetChangeComponent', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should correctly generate panel for increaseAllowance()', () => {
+    const stateChanges: StateChange[] = [
+      {
+        assetType: SimulationAssetTypes.ERC20,
+        changeType: StateChangeType.Approve,
+        address: '0x123',
+        amount: '100',
+        symbol: 'ENS',
+        decimals: 18,
+        contractAddress: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
+        name: 'Ethereum Name Service',
+        logo: 'https://example.com/logo.png',
+        tokenID: '',
+        tokenURI: '',
+        tokenName: '',
+        openSeaFloorPrice: 0,
+        openSeaVerified: false,
+        openSeaLink: '',
+        etherscanVerified: true,
+        etherscanLink: 'https://etherscan.io',
+        coinmarketcapLink: 'https://coinmarketcap.com',
+        message: 'They can withdraw 100 ENS',
+        fiatValue: '',
+      },
+    ];
+
+    const expected = panel([
+      heading('➡️ You are giving approval:'),
+      text('100 ENS'),
+    ]);
+    const actual = AssetChangeComponent(StateChangeType.Approve, stateChanges);
+    expect(actual).toStrictEqual(expected);
+  });
+
   it('should handle empty stateChanges array correctly', () => {
     const stateChanges: StateChange[] = [];
     const expected = panel([heading('➡️ You are sending:')]);

--- a/packages/snap/src/components/StateChangesComponent.ts
+++ b/packages/snap/src/components/StateChangesComponent.ts
@@ -1,4 +1,4 @@
-import { Component, Panel, panel } from '@metamask/snaps-ui';
+import { Component, Panel, divider, panel } from '@metamask/snaps-ui';
 import {
   SimulatedGas,
   StateChange,
@@ -34,15 +34,32 @@ export const StateChangesComponent = (
     (stateChange) => stateChange.changeType === StateChangeType.Transfer,
   );
 
-  // Show transferring assets first and always show it because there will be a gas fee
-  output.push(
-    AssetChangeComponent(StateChangeType.Transfer, transferChanges, gas),
+  const approvalChanges = stateChanges.filter(
+    (stateChange) => stateChange.changeType === StateChangeType.Approve,
   );
 
-  // Show receiving assets second
-  if (receiveChanges?.length > 0) {
-    output.push(AssetChangeComponent(StateChangeType.Receive, receiveChanges));
+  // Show transferring assets first and show a gas estimate if there is one
+  if (transferChanges.length > 0 || gas) {
+    output.push(
+      AssetChangeComponent(StateChangeType.Transfer, transferChanges, gas),
+    );
+    output.push(divider());
   }
+
+  // Show receiving assets second
+  if (receiveChanges.length > 0) {
+    output.push(AssetChangeComponent(StateChangeType.Receive, receiveChanges));
+    output.push(divider());
+  }
+
+  // Show approval changes
+  if (approvalChanges.length > 0) {
+    output.push(AssetChangeComponent(StateChangeType.Approve, approvalChanges));
+    output.push(divider());
+  }
+
+  // Remove the final divider at the end of state changes
+  output.pop();
 
   return panel(output);
 };

--- a/packages/snap/src/components/assetChanges/AssetChangeComponent.ts
+++ b/packages/snap/src/components/assetChanges/AssetChangeComponent.ts
@@ -43,9 +43,11 @@ const getHeader = (changeType: StateChangeType): Heading => {
   // add more ChangeType mappings here as they are supported
   switch (changeType) {
     case StateChangeType.Receive:
-      return heading('You are receiving:');
+      return heading('⬅️ You are receiving:');
     case StateChangeType.Transfer:
-      return heading('You are sending:');
+      return heading('➡️ You are sending:');
+    case StateChangeType.Approve:
+      return heading('➡️ You are giving approval:');
     default:
       return heading('');
   }

--- a/packages/snap/src/types/simulateApi.ts
+++ b/packages/snap/src/types/simulateApi.ts
@@ -156,4 +156,5 @@ export enum ErrorType {
 export enum StateChangeType {
   Receive = 'RECEIVE',
   Transfer = 'TRANSFER',
+  Approve = 'APPROVE',
 }


### PR DESCRIPTION
Changes:
- Improvements to the UI by adding emojis for sending/receiving
- Adds `approval` state changes which adds coverage for the `increaseAllowance` method call
- Increments version to 1.0.2

New UI:
![image](https://github.com/wallet-guard/wallet-guard-snap/assets/72634565/549361d2-eb61-403b-bddd-aad091ca909d)

This is the case that was missing:
![image](https://github.com/wallet-guard/wallet-guard-snap/assets/72634565/0c571b0d-c883-493e-a9fb-9f9e9383e0c0)

