### PR TITLE
Fix: Cron job for approvals. Add slight buffer to frequency

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -32,7 +32,7 @@
     "endowment:cronjob": {
       "jobs": [
         {
-          "expression": "0 0 */14 * *",
+          "expression": "0 0 */16 * *",
           "request": {
             "method": "checkApprovals",
             "params": {}


### PR DESCRIPTION
The problem - currently we run every 14d which causes the cron job to run on the 1st, 15th, 29th, 1st, 15th, 29th, and so on. The problem is that there's only a handful of days between the 29th and 1st so we're going to be running it more frequently than intended.

Here's the tool I'm using for reference
https://cronjob.xyz/

*BEFORE*
![image](https://github.com/wallet-guard/wallet-guard-snap/assets/72634565/aaef5dcd-8862-403b-92f2-d82be2505d59)

*AFTER*
![image](https://github.com/wallet-guard/wallet-guard-snap/assets/72634565/04a58697-e758-4496-a660-0cccc6935767)
